### PR TITLE
Add logo connection to DATS.json

### DIFF
--- a/DATS.json
+++ b/DATS.json
@@ -145,6 +145,14 @@
         }
       ]
     },
+ 	{
+      "category": "logo",
+      "values": [
+        {
+          "value": "logo.png"
+        }
+      ]
+    },
     {
       "category": "REB_statement",
       "values": [


### PR DESCRIPTION
This PR adds a `logo` value to `extraProperties` in the DATS.json file.